### PR TITLE
Add GitHub Skills Activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills through GitHub. Part of the GitHub Certifications program to help with college applications",
+        "schedule": "Mondays and Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Summary
This PR adds the missing GitHub Skills activity that was announced by the principal.

## Changes
- Added "GitHub Skills" to the activities list in `src/app.py`
- Activity includes description about the GitHub Certifications program
- Schedule: Mondays and Wednesdays, 3:30 PM - 5:00 PM
- Capacity: 25 students
- Currently has no participants (ready for new signups)

## Issue
Resolves #6 

## Context
Students have been waiting to sign up for this activity since the principal's announcement. This is time-sensitive as registrations close at the end of this week. The activity is part of the GitHub Certifications program which will help students with their college applications.